### PR TITLE
2021 08 06

### DIFF
--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -17180,7 +17180,9 @@ function playerPower()
 	return playerShipScore
 end
 function wrapAddCustomButtons(p)
-	p.wrappedAddCustomButton = function(...) customElements:addCustomButton(...) end -- count - 45
+	p.wrappedAddCustomButton = function(player,position,name,caption,callback) -- missing index for next EE version
+		customElements:addCustomButton(player,position,name,caption,wrapWithErrorHandling(callback))
+	end -- count - 45
 	p.wrappedAddCustomInfo = function(...) customElements:addCustomInfo(...) end -- count 5
 	p.wrappedAddCustomMessageWithCallback = function(...) customElements:addCustomMessageWithCallback(...) end
 	p.wrappedAddCustomMessage = function(...) customElements:addCustomMessage(...) end -- count 45

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -12,7 +12,6 @@
 -- mineRingShim while allowing nice things with complex defences (see research base) deserves looking at some more to see about simplifcation, at least for the common case, if there is no obvious improvement document it better at least
 -- getScenarioTime should allow some small simplifcations
 -- callbacks need error checking, compare wrapWithErrorHandling and callWithErrorHandling
--- the edit I made to use onNewPlayerShip I think will be missfiring with the setTemplate type rather than the rebuilt type fix
 -- consider looking trying to improve player ship creation, with the new invaraints offered by onNewPlayerShip, at least try to suggest a way that only needs 2 editing points for new ships rather than 3
 -- consider making a printable stack block for a ship to aid the "what is this ship" question (probably via lua making an SVG?)
 -- try to merge in a for the rift devices at long last (getting closer with the update system but still a way off)
@@ -17204,6 +17203,9 @@ function assignPlayerShipScore(p)
 	p.mining = false
 	p.max_pods = 1
 	p.pods = p.max_pods
+	updatePlayerSoftTemplate(p)
+end
+function updatePlayerSoftTemplate(p)
 	local tempTypeName = p:getTypeName()
 --	print("assign player ship score, temp type name",tempTypeName)
 	if tempTypeName ~= nil then
@@ -35535,9 +35537,12 @@ function updateInner(delta)
 		local p = getPlayerShip(pidx)
 		if p ~= nil and p:isValid() then
 			if updateDiagnostic then print("update: valid player: adjust spawn point") end
+			-- if the template has been update pull data from the soft template
+			-- even if templates arent changed this can happen during inital creation
+			-- as setTemplate will invoke the callback with the template before being
+			-- overwritten by the soft template
 			if p.score_settings_source ~= p:getTypeName() then
-				assignPlayerShipScore(p)
---				print("assignPlayerScore or perhaps onNewPlayerShip did not get it right the first time, so it is being called again")
+				updatePlayerSoftTemplate(p)
 			end
 			local player_name = p:getCallSign()
 			if warning_station ~= nil then

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -24,7 +24,7 @@ require("science_database.lua")
 require("utils_customElements.lua")
 function init()
 	print("Empty Epsilon version: ",getEEVersion())
-	scenario_version = "3.5.23"
+	scenario_version = "3.5.24"
 	print(string.format("     -----     Scenario: Sandbox     -----     Version %s     -----",scenario_version))
 	print(_VERSION)	--Lua version
 	updateDiagnostic = false
@@ -30975,7 +30975,7 @@ end
 -- version display the red text with a line number that init code does
 -- example addGMFunction("button",wrapWithErrorHandling(function () print("example") end))
 function wrapWithErrorHandling(fun)
-	assert(type(fun)=="function" or fun==nil)
+	assert(type(fun)=="function" or fun==nil,"expected function or nil for wrapWithErrorHandling we instead got a " .. type(fun) .. " with a value of " .. tostring(fun))
 	if fun == nil then
 		return nil
 	end

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -17182,11 +17182,11 @@ end
 function wrapAddCustomButtons(p)
 	p.wrappedAddCustomButton = function(player,position,name,caption,callback) -- missing index for next EE version
 		customElements:addCustomButton(player,position,name,caption,wrapWithErrorHandling(callback))
-	end -- count - 45
-	p.wrappedAddCustomInfo = function(...) customElements:addCustomInfo(...) end -- count 5
+	end
+	p.wrappedAddCustomInfo = function(...) customElements:addCustomInfo(...) end
 	p.wrappedAddCustomMessageWithCallback = function(...) customElements:addCustomMessageWithCallback(...) end
-	p.wrappedAddCustomMessage = function(...) customElements:addCustomMessage(...) end -- count 45
-	p.wrappedRemoveCustom = function(...) customElements:removeCustom(...) end -- count 68
+	p.wrappedAddCustomMessage = function(...) customElements:addCustomMessage(...) end
+	p.wrappedRemoveCustom = function(...) customElements:removeCustom(...) end
 end
 function assignPlayerShipScore(p)
 	wrapAddCustomButtons(p)

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -1444,26 +1444,20 @@ function fleetCustom:addToFleet(player)
 	end
 end
 
--- the ... in these functions is to try to enable support for
--- both 2021623 and the yet unreleased version with an index
--- parameter, its kind of ugly, but should work as expected
--- small simplificatios may be possible in the next offical release
--- when dropping support for 2021623 (for the benefit of searching -
--- 2021623 may be known as 20210623 )
-function fleetCustom:addCustomButton(position,name,...)
+function fleetCustom:addCustomButton(position,name,caption,callback,order)
 	self:_gc()
 	for _,p in pairs(self._player_list) do
-		p:wrappedAddCustomButton(position,name,...)
+		p:wrappedAddCustomButton(position,name,caption,callback,order)
 	end
-	self._custom_info[name]={"wrappedAddCustomButton",position,name,...}
+	self._custom_info[name]={"wrappedAddCustomButton",position,name,caption,callback,order}
 end
 
-function fleetCustom:addCustomInfo(player,...)
+function fleetCustom:addCustomInfo(player,position,name,caption,order)
 	self:_gc()
 	for _,p in pairs(self._player_list) do
-		p:wrappedAddCustomInfo(position,name,...)
+		p:wrappedAddCustomInfo(position,name,caption,order)
 	end
-	self._custom_info[name]={"wrappedAddCustomInfo",position,name,...}
+	self._custom_info[name]={"wrappedAddCustomInfo",position,name,caption,order}
 end
 
 -- we arent even going to try to cache messages, we have no way to tell
@@ -1471,18 +1465,18 @@ end
 -- its possible if we wrap calls round addCustomMessage we could make it work
 -- but it opens questions like "do we show this if one ship has closed and one has opened"
 -- this is a logical thing to implement if it ends up being wanted though
-function fleetCustom:addCustomMessage(...)
+function fleetCustom:addCustomMessage(position,name,caption)
 	self:_gc()
 	for _,p in pairs(self._player_list) do
-		p:wrappedAddCustomMessage(...)
+		p:wrappedAddCustomMessage(position,name,caption)
 	end
 end
 
 -- see addCustomMessage
-function fleetCustom:addCustomMessageWithCallback(...)
+function fleetCustom:addCustomMessageWithCallback(position,name,caption,callback)
 	self:_gc()
 	for _,p in pairs(self._player_list) do
-		p:wrappedAddCustomMessageWithCallback(...)
+		p:wrappedAddCustomMessageWithCallback(position,name,caption,callback)
 	end
 end
 

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -31008,7 +31008,13 @@ function addGMFunction(msg, fun)
 	assert(type(fun)=="function" or fun==nil)
 	return addGMFunctionReal(msg,wrapWithErrorHandling(fun))
 end
--- we have the same issue with onGMClick, wrap that as well
+
+onNewPlayerShipReal=onNewPlayerShip
+function onNewPlayerShip(fun)
+	assert(type(fun)=="function" or fun==nil)
+	return onNewPlayerShipReal(wrapWithErrorHandling(fun))
+end
+
 onGMClickReal=onGMClick
 function onGMClick(fun)
 	assert(type(fun)=="function" or fun==nil)


### PR DESCRIPTION
misc small clean ups

fleetCustom isnt used yet, its had insufficent testing, but is so isolated it shouldnt break anything.

The intent with it is to make newly created ships have the same buttons/labels as ships created before. I need something like this to for example add a gm button to all player ships and update when new ships are created.

I will port other code to it, but figured as I need to call it a day it was better in the main repo.