### PR TITLE
Web tool 2

### DIFF
--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -404,7 +404,13 @@ function isValidVariableDescriptionType(type_str)
 		return false
 	end
 end
-
+function isWebTableFunction(tbl)
+	if type(tbl)=="table" and tbl.call ~= nil and type(tbl.call) == "string" then
+		return true
+	else
+		return false
+	end
+end
 function checkVariableDescriptions(args_table)
 	for arg_num,arg_description in pairs(args_table) do
 		local arg_name = arg_description[1]
@@ -420,9 +426,9 @@ function checkVariableDescriptions(args_table)
 		local arg_default = arg_description[3]
 		if arg_default ~= nil then
 			-- this is to check the default argument if present is of the correct type
-			-- sadly it is much harder to check functions as they wont run in the order expected
+			-- sadly it is much harder to check functions as they will be checked as defined
 			-- as such we will just assume they are OK for now
-			if arg_type ~= "function" then
+			if not isWebTableFunction(arg_default) then
 				webConvertArgument(arg_default,arg_description)
 			end
 		end
@@ -491,10 +497,7 @@ end
 -- only copes with converting functions from the web calling table format
 function webConvertScalar(value, argSettings)
 	local convert_to = argSettings[2]
-	local is_web_function = false
-	if type(value) == "table" and type(value.call) == "string" then
-		is_web_function = true
-	end
+	local is_web_function = isWebTableFunction(value)
 	if is_web_function and convert_to ~= "function" then
 		value = indirectCall(value)
 	end
@@ -545,8 +548,7 @@ end
 function convertWebCallTableToFunction(args,caller_provides)
 	local caller_provides = caller_provides or {}
 	assert(type(caller_provides)=="table")
-	assert(type(args)=="table")
-	assert(type(args.call)=="string")
+	assert(isWebTableFunction(args))
 	local requested_function = getScriptStorage()._cuf_gm.functions[args.call]
 	assert(requested_function ~= nil, "attempted to call an undefined function " .. args.call)
 	assert(type(requested_function.fn) == "function")

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -440,7 +440,7 @@ function checkVariableDescriptions(args_table)
 				assert(arg_type == "number")
 			elseif arg_name == "max" then
 				assert(arg_type == "number")
-			elseif arg_name == "caller_provides" ~= nil then
+			elseif arg_name == "caller_provides" then
 				assert(arg_type == "function")
 			else
 				assert(false,"arg_description has a key that describeFunction doesnt about")

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -412,7 +412,7 @@ function isWebTableFunction(tbl)
 	end
 end
 function checkVariableDescriptions(args_table)
-	for arg_num,arg_description in pairs(args_table) do
+	for _,arg_description in ipairs(args_table) do
 		local arg_name = arg_description[1]
 		assert(type(arg_name)=="string")
 		-- _this is the name for the table describing the current function, we cant also have an argument of _this

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -396,6 +396,207 @@ function webUploadEndAndRunAndFree(slot)
 		return {error = err}
 	end
 end
+function isValidVariableDescriptionType(type_str)
+	assert(type(type_str) == "string")
+	if type_str == "string" or type_str == "number" or type_str == "position" or type_str == "npc_ship_template" or type_str == "function" then
+		return true
+	else
+		return false
+	end
+end
+
+function checkVariableDescriptions(args_table)
+	for arg_num,arg_description in pairs(args_table) do
+		local arg_name = arg_description[1]
+		assert(type(arg_name)=="string")
+		-- _this is the name for the table describing the current function, we cant also have an argument of _this
+		assert(arg_name ~= "_this")
+		-- call as an argument name would cause an alarming degree of chaos
+		assert(arg_name ~= "call")
+
+		local arg_type = arg_description[2]
+		assert(isValidVariableDescriptionType(arg_type))
+
+		local arg_default = arg_description[3]
+		if arg_default ~= nil then
+			-- this is to check the default argument if present is of the correct type
+			-- sadly it is much harder to check functions as they wont run in the order expected
+			-- as such we will just assume they are OK for now
+			if arg_type ~= "function" then
+				webConvertArgument(arg_default,arg_description)
+			end
+		end
+		for arg_name,arg_value in pairs(arg_description) do
+			if arg_name == 1 or arg_name == 2 or arg_name == 3 then
+			elseif arg_name == 4 then
+				assert(arg_value == "array")
+			elseif arg_name == "min" then
+				assert(arg_type == "number")
+			elseif arg_name == "max" then
+				assert(arg_type == "number")
+			elseif arg_name == "caller_provides" ~= nil then
+				assert(arg_type == "function")
+			else
+				assert(false,"arg_description has a key that describeFunction doesnt about")
+			end
+		end
+	end
+end
+
+-- the name is better as describeAndExportFunctionForWeb, but there are going to be an absurd number
+-- of these so brevity is important, I have no objection if a find and replace is desired
+--
+-- description format is
+-- 1) name of the function as a string (the function call itself is pulled out of the global table)
+--                         as such anonymous functions are presently not supported
+-- 2) function description, which is a table or a string or nil
+--              if it is a string then it is assumed as being function_description[1]
+-- 2.1) function_description[1] is a description used for the web tool
+-- 2.2) function_description[2+] is a list of tags to be used for sorting on the web UI
+-- 3) args_table a table of tables is an optional table describing each argument given to the function
+-- 3.0) each inner table is defined as follows
+-- 3.1) [1] name of the argument
+-- 3.2) [2] type of the argument - see below for types
+-- 3.3) [3] the default value for the argument, note this is not checked for type/value and is current web tool only
+-- 3.4) [4] may be the string "array" in which case this is a table from [1] to #table, this is badly tested, but required for the web tool, if this is going to be used elsewhere better testing is needed
+-- 3.4) the remainder of the table is optional tags based on type
+-- for numbers -
+-- min - minimum value expected
+-- max - maximum value expected
+-- for function
+-- caller_provides - the values this function provides for the function call (this will stop them being shown on the web tool)
+--
+-- types
+-- string - a lua string - example = "the answer"
+-- number - a lua number - example = 42
+-- position - a table of 2 numbers - {x,y} - example = {x = 6, y = 9}
+-- npc_ship_template - the template name for a npc ship, this can be set to valid softtemplates or stock templates - example "Adder MK4"
+-- function - the caller recives a function to be called, the caller provides a table which will be converted by convertWebCallTableToFunction - example = {call = getCpushipSoftTemplates} renaming the caller_provides list is possible with a table called _caller_provides_rename - look at webConvertScalar for details
+function describeFunction(name,function_description,args_table)
+	assert(type(name)=="string")
+	assert(type(function_description) == "table" or type(function_description) == "string" or function_description == nil)
+	if type(function_description) ~= "table" then
+		function_description = {function_description}
+	end
+	assert(type(args_table)=="table" or args_table == nil)
+	args_table = args_table or {}
+	local fn = _ENV[name]
+	assert(type(fn)=="function",name)
+	checkVariableDescriptions(args_table)
+	args_table._this = function_description
+	getScriptStorage()._cuf_gm.functions[name] = {fn = fn, args = args_table}
+end
+
+-- convert a single value from a web call
+-- only copes with converting functions from the web calling table format
+function webConvertScalar(value, argSettings)
+	local convert_to = argSettings[2]
+	local is_web_function = false
+	if type(value) == "table" and type(value.call) == "string" then
+		is_web_function = true
+	end
+	if is_web_function and convert_to ~= "function" then
+		value = indirectCall(value)
+	end
+	if convert_to == "function" then
+		local caller_provides = {}
+		if argSettings.caller_provides then
+			for _,var in pairs(argSettings.caller_provides) do
+				if value._caller_provides_rename ~= nil then
+					if value._caller_provides_rename[var] ~= nil then
+						var = value._caller_provides_rename[var]
+					end
+				end
+				table.insert(caller_provides,var)
+			end
+		end
+		value = convertWebCallTableToFunction(value,caller_provides)
+		assert(type(value) == "function")
+	elseif convert_to == "string" then
+		assert(type(value) == "string")
+	elseif convert_to == "number" then
+		-- it is worth considering if min / max should be checked here or not
+		assert(type(value) == "number")
+	elseif convert_to == "position" then
+		assert(type(value) == "table")
+		assert(type(value.x) == "number")
+		assert(type(value.y) == "number")
+	elseif convert_to == "npc_ship_template" then
+		-- checking this is a valid template name would be nice
+		assert(type(value) == "string")
+	else
+		assert(false,"unknown type " .. "\"" .. convert_to .. "\"")
+	end
+	return value
+end
+
+function webConvertArgument(value, argSettings)
+	local is_array = (argSettings[4] == "array")
+	if is_array then
+		for idx,scalar in ipairs(value) do
+			value[idx] = webConvertScalar(scalar, argSettings)
+		end
+	else
+		value = webConvertScalar(value, argSettings)
+	end
+	return value
+end
+
+function convertWebCallTableToFunction(args,caller_provides)
+	local caller_provides = caller_provides or {}
+	assert(type(caller_provides)=="table")
+	assert(type(args)=="table")
+	assert(type(args.call)=="string")
+	local requested_function = getScriptStorage()._cuf_gm.functions[args.call]
+	assert(requested_function ~= nil, "attempted to call an undefined function " .. args.call)
+	assert(type(requested_function.fn) == "function")
+	assert(type(requested_function.args) == "table")
+	local do_we_need_to_wrap = false
+	for arg_num,arg in ipairs(requested_function.args) do
+		if arg[1] ~= caller_provides[arg_num] then
+			do_we_need_to_wrap = true
+		end
+		if arg[2] == "function" then
+			do_we_need_to_wrap = true
+		end
+	end
+	if not do_we_need_to_wrap then
+		return requested_function.fn
+	end
+	return function (...)
+		local callee_args = {}
+		local arg_num = 1
+		for _,arg in ipairs(requested_function.args) do
+			local arg_name = arg[1]
+			local in_caller_provides = nil
+			for arg_num,suppressed in ipairs(caller_provides) do
+				if suppressed == arg_name then
+					in_caller_provides = arg_num
+				end
+			end
+			local value
+			if in_caller_provides then
+				assert(select("#",...)<= in_caller_provides)
+				value = select(in_caller_provides,...)
+			elseif args[arg_name] then
+				value = args[arg_name]
+			else
+				value = arg.default
+				assert(value ~= nil,"argument not in list " .. arg_name .. " for function " .. args.call .. " (and there is no default)")
+			end
+			callee_args[arg_num] = webConvertArgument(value,arg)
+			arg_num = arg_num +1
+		end
+		-- reminder it is possible for entires in requested_function can be nil
+		return requested_function.fn(table.unpack(callee_args,1,#requested_function.args))
+	end
+end
+
+-- this is the entry point for the web gm tool
+function indirectCall(args)
+	return callWithErrorHandling(convertWebCallTableToFunction(args))
+end
+
 function setupWebGMTool()
 	-- currently (2021/09/02) getScriptStorage() bleeds through
 	-- scenario restarts, this is a problem, I am also willfully
@@ -417,15 +618,24 @@ function setupWebGMTool()
 		},
 		-- all the functions exported to the web tool
 		functions = {
-			-- an array of elements with a fn and args element
-			-- needs better documentation when add_function is moved here from the web tool
-			-- currently somewhat in flux
+			-- see describeFunction for details
 		},
 		webUploadStart = webUploadStart,
 		webUploadEndAndRunAndFree = webUploadEndAndRunAndFree,
-		webUploadSegment = webUploadSegment
+		webUploadSegment = webUploadSegment,
+		indirectCall = indirectCall
 	}
 end
+-- we need to call this outside of the init functions as otherwise describeFunction wont work after functions themselves
+setupWebGMTool()
+
+-- stock EE / lua functions
+describeFunction("irandom",nil,
+	{
+		{"min","number"},
+		{"max","number"}
+	})
+
 function setConstants()
 	customElements:modifyOperatorPositions("name_tag_positions",{"Relay","Operations","ShipLog","Helms","Tactical"})
 	universe=universe()
@@ -618,7 +828,6 @@ function setConstants()
 		["Odin"] =				{strength = 250,adder = false,	missiler = false,	beamer = false,	frigate = false,	chaser = true,	fighter = false,	drone = false,	unusual = false,	base = false,	short_range_radar = 20000,	hop_angle = 0,	hop_range = 3180,	create = stockTemplate},
 		["Loki"] =				{strength = 260,adder = false,	missiler = false,	beamer = false,	frigate = false,	chaser = true,	fighter = false,	drone = false,	unusual = false,	base = false,	short_range_radar = 20000,	hop_angle = 0,	hop_range = 3180,	create = loki},
 	}
-	setupWebGMTool()
 	fleet_group = {
 		["adder"] = "Adders",
 		["Adders"] = "adder",

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -27123,70 +27123,77 @@ function supplyCreation(originx, originy, vectorx, vectory)
 	local supplyMine = math.random(supply_mine_range_min,supply_mine_range_max)
 	local supplyHoming = math.random(supply_homing_range_min,supply_homing_range_max)
 	local supplyHVLI = math.random(supply_hvli_range_min,supply_hvli_range_max)
-	local customSupplyDrop = SupplyDrop():setEnergy(supplyEnergy):setFaction("Human Navy"):setPosition(originx+vectorx,originy+vectory)
-	customSupplyDrop:setWeaponStorage("Nuke",supplyNuke)
-	customSupplyDrop:setWeaponStorage("EMP",supplyEMP)
-	customSupplyDrop:setWeaponStorage("Homing",supplyHoming)
-	customSupplyDrop:setWeaponStorage("Mine",supplyMine)
-	customSupplyDrop:setWeaponStorage("HVLI",supplyHVLI)
 	local supplyRepairCrew = math.random(supply_repair_crew_range_min,supply_repair_crew_range_max)
-	if supplyRepairCrew > 0 then
-		customSupplyDrop.repairCrew = supplyRepairCrew
-	end
 	local supplyCoolant = math.random(supply_coolant_range_min,supply_coolant_range_max)
-	if supplyCoolant > 0 then
-		customSupplyDrop.coolant = supplyCoolant
-	end
 	local supplyProbes = math.random(supply_probes_range_min,supply_probes_range_max)
-	if supplyProbes > 0 then
-		customSupplyDrop.probes = supplyProbes
-	end
 	local supplyArmor = math.random(supply_armor_range_min,supply_armor_range_max)
-	if supplyArmor > 0 then
-		customSupplyDrop.armor = supplyArmor
+	createSupplyDrop({x = originx+vectorx, y = originy+vectory},supplyEnergy,supplyHoming,supplyNuke,supplyMine,supplyEMP,supplyHVLI,supplyRepairCrew,supplyCoolant,supplyProbes,supplyArmor)
+end
+function createSupplyDrop(location,energy,homing,nuke,mine,emp,hvli,repairCrew,coolant,probes,armour)
+	print(location.x,location.y,energy,homing,nuke,mine,emp,hvli,repairCrew,coolant,probes,armour)
+	local customSupplyDrop = SupplyDrop():setEnergy(energy):setFaction("Human Navy"):setPosition(location.x,location.y)
+	customSupplyDrop:setWeaponStorage("Nuke",nuke)
+	customSupplyDrop:setWeaponStorage("EMP",emp)
+	customSupplyDrop:setWeaponStorage("Homing",homing)
+	customSupplyDrop:setWeaponStorage("Mine",mine)
+	customSupplyDrop:setWeaponStorage("HVLI",hvli)
+	if repairCrew > 0 then
+		customSupplyDrop.repairCrew = repairCrew
+	end
+	if coolant > 0 then
+		customSupplyDrop.coolant = coolant
+	end
+	if probes > 0 then
+		customSupplyDrop.probes = probes
+	end
+	if armour > 0 then
+		customSupplyDrop.armor = armour
 	end
 	local supplyLabel = ""
 	local wordy_label = ""
-	if supplyEnergy > 0 then
-		supplyLabel = supplyLabel .. string.format("B%i ",supplyEnergy)
-		wordy_label = wordy_label .. string.format("Battery Power:%i ",supplyEnergy)
+	if energy > 0 then
+		supplyLabel = supplyLabel .. string.format("B%i ",energy)
+		wordy_label = wordy_label .. string.format("Battery Power:%i ",energy)
 	end
-	if supplyNuke > 0 then
-		supplyLabel = supplyLabel .. string.format("N%i ",supplyNuke)
-		wordy_label = wordy_label .. string.format("Nukes:%i ",supplyNuke)
+	if nuke > 0 then
+		supplyLabel = supplyLabel .. string.format("N%i ",nuke)
+		wordy_label = wordy_label .. string.format("Nukes:%i ",nuke)
 	end
-	if supplyEMP > 0 then
-		supplyLabel = supplyLabel .. string.format("E%i ",supplyEMP)
-		wordy_label = wordy_label .. string.format("EMPs:%i ",supplyEMP)
+	if emp > 0 then
+		supplyLabel = supplyLabel .. string.format("E%i ",emp)
+		wordy_label = wordy_label .. string.format("EMPs:%i ",emp)
 	end
-	if supplyMine > 0 then
-		supplyLabel = supplyLabel .. string.format("M%i ",supplyMine)
-		wordy_label = wordy_label .. string.format("Mines:%i ",supplyMine)
+	if mine > 0 then
+		supplyLabel = supplyLabel .. string.format("M%i ",mine)
+		wordy_label = wordy_label .. string.format("Mines:%i ",mine)
 	end
-	if supplyHoming > 0 then
-		supplyLabel = supplyLabel .. string.format("H%i ",supplyHoming)
-		wordy_label = wordy_label .. string.format("Homing Missiles:%i ",supplyHoming)
+	if homing > 0 then
+		supplyLabel = supplyLabel .. string.format("H%i ",homing)
+		wordy_label = wordy_label .. string.format("Homing Missiles:%i ",homing)
 	end
-	if supplyHVLI > 0 then
-		supplyLabel = supplyLabel .. string.format("L%i ",supplyHVLI)
-		wordy_label = wordy_label .. string.format("High Velocity Lead Impactors:%i ",supplyHVLI)
+	if hvli > 0 then
+		supplyLabel = supplyLabel .. string.format("L%i ",hvli)
+		wordy_label = wordy_label .. string.format("High Velocity Lead Impactors:%i ",hvli)
 	end
-	if supplyRepairCrew > 0 then
-		supplyLabel = supplyLabel .. string.format("R%i ",supplyRepairCrew)
-		wordy_label = wordy_label .. string.format("Robotic Repair Crew:%i ",supplyRepairCrew)
+	if repairCrew > 0 then
+		supplyLabel = supplyLabel .. string.format("R%i ",repairCrew)
+		wordy_label = wordy_label .. string.format("Robotic Repair Crew:%i ",repairCrew)
 	end
-	if supplyCoolant > 0 then
-		supplyLabel = supplyLabel .. string.format("C%i ",supplyCoolant)
-		wordy_label = wordy_label .. string.format("Coolant:%i ",supplyCoolant)
+	if coolant > 0 then
+		supplyLabel = supplyLabel .. string.format("C%i ",coolant)
+		wordy_label = wordy_label .. string.format("Coolant:%i ",coolant)
 	end
-	if supplyProbes > 0 then
-		supplyLabel = supplyLabel .. string.format("P%i ",supplyProbes)
-		wordy_label = wordy_label .. string.format("Probes:%i ",supplyProbes)
+	if probes > 0 then
+		supplyLabel = supplyLabel .. string.format("P%i ",probes)
+		wordy_label = wordy_label .. string.format("Probes:%i ",probes)
 	end
-	if supplyArmor > 0 then
-		supplyLabel = supplyLabel .. string.format("A%i ",supplyArmor)
-		wordy_label = wordy_label .. string.format("Armor:%i ",supplyArmor)
+	if armour > 0 then
+		supplyLabel = supplyLabel .. string.format("A%i ",armour)
+		wordy_label = wordy_label .. string.format("Armor:%i ",armour)
 	end
+	-- this really wants to be a function argument, but that will want enum support for the web interface ideally
+	-- aka this is on the list but cant be done right now
+	print(supplyLabel,wordy_label)
 	if supply_drop_info == "Label" then
 		customSupplyDrop:setCallSign(supplyLabel)
 	elseif supply_drop_info == "Scan" then
@@ -27198,6 +27205,21 @@ function supplyCreation(originx, originy, vectorx, vectory)
 	end
 	customSupplyDrop:onPickUp(supplyPickupProcess)
 end
+describeFunction("createSupplyDrop",
+	"create a custom supply drop at a location",
+	{	{"location","position"},
+		{"energy","number", {call = "irandom", min = 0, max = 500}, min = 0},
+		{"homing","number", {call = "irandom", min = 0, max = 5}, min = 0},
+		{"nuke","number", {call = "irandom", min = 0, max = 5}, min = 0},
+		{"mine","number", {call = "irandom", min = 0, max = 5}, min = 0},
+		{"emp","number", {call = "irandom", min = 0, max = 5}, min = 0},
+		{"hvli","number", {call = "irandom", min = 0, max = 5}, min = 0},
+		{"repairCrew","number", {call = "irandom", min = 0, max = 1}, min = 0},
+		{"coolant","number", {call = "irandom", min = 0, max = 2}, min = 0},
+		{"probes","number", {call = "irandom", min = 0, max = 5}, min = 0},
+		{"armour","number", {call = "irandom", min = 0, max = 30}, min = 0},
+	})
+
 function supplyPickupProcess(self, player)
 	if self.repairCrew ~= nil then
 		player:setRepairCrewCount(player:getRepairCrewCount() + self.repairCrew)

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -10,7 +10,6 @@
 -- Starry's todo list
 -- test spliting out region, understand what is necessary and consider switching away from the table returning everything if it works
 -- mineRingShim while allowing nice things with complex defences (see research base) deserves looking at some more to see about simplifcation, at least for the common case, if there is no obvious improvement document it better at least
--- getScenarioTime should allow some small simplifcations
 -- callbacks need error checking, compare wrapWithErrorHandling and callWithErrorHandling
 -- consider looking trying to improve player ship creation, with the new invaraints offered by onNewPlayerShip, at least try to suggest a way that only needs 2 editing points for new ships rather than 3
 -- consider making a printable stack block for a ship to aid the "what is this ship" question (probably via lua making an SVG?)
@@ -442,7 +441,6 @@ function setConstants()
 	universe:addAvailableRegion("Teresh (K44)",tereshSector,800001,120001)
 	universe:addAvailableRegion("Santa Containment(J41)",santaContainment,754554, 64620)-- probably worth considering as temporary
 	initialSandboxDatabaseUpdate()
-	scenarioTime = 0
 	playerSpawnX = 0
 	playerSpawnY = 0
 	prefix_length = 0

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -31072,6 +31072,11 @@ end
 function setTimerPurpose(purpose)
 	timer_purpose = purpose
 end
+describeFunction("setTimerPurpose",
+	"change the purpose of the current timer",
+	{
+		{"Purpose", "string"},
+	})
 -------------------------------------
 --	Countdown Timer > Add Seconds  --
 -------------------------------------

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -570,6 +570,7 @@ function convertWebCallTableToFunction(args,caller_provides)
 		local arg_num = 1
 		for _,arg in ipairs(requested_function.args) do
 			local arg_name = arg[1]
+			local arg_default = arg[3]
 			local in_caller_provides = nil
 			for arg_num,suppressed in ipairs(caller_provides) do
 				if suppressed == arg_name then
@@ -583,7 +584,7 @@ function convertWebCallTableToFunction(args,caller_provides)
 			elseif args[arg_name] then
 				value = args[arg_name]
 			else
-				value = arg.default
+				value = arg_default
 				assert(value ~= nil,"argument not in list " .. arg_name .. " for function " .. args.call .. " (and there is no default)")
 			end
 			callee_args[arg_num] = webConvertArgument(value,arg)

--- a/scenario_09_sandbox.lua
+++ b/scenario_09_sandbox.lua
@@ -4747,11 +4747,15 @@ function countdownTimer()
 		end)
 	else
 		addGMFunction("Start Timer", function()
-			timer_started = true
+			startTimer()
 			countdownTimer()
 		end)
 	end
 end
+function startTimer()
+	timer_started = true
+end
+describeFunction("startTimer","starts the gm configured timer")
 function coloredSubspaceRift (x,y,destination_x,destination_y)
 	local artifact = Artifact():setPosition(x,y):setCallSign("Subspace rift")
 	local all_objs = {}


### PR DESCRIPTION
the commit that has most important of the changes is - https://github.com/Xansta/EEScenarios/commit/827506c4d13b966df99d604fc3af3c77d31175d3

I said on discord I would try to include some examples so .....

lets start basic - currently for startTimer the web interface would call
`return getScriptStorage()._cuf_gm.indirectCall({call = "startTimer"})`
in order to trigger that

slightly harder - arguments can be given like this
`return getScriptStorage()._cuf_gm.indirectCall({Purpose = "a really good reason, fear the GM players",call = "setTimerPurpose"})`
(call would be better at the beginning, I mean to fix this in the web side soon)

onGMClick isnt great being exported yet as I need work on it on the web side

the export for `createSupplyDrop` doesnt currently show correctly in the web client - this is quite fixable though, but is included so as to give a example of using return values for arguments as would be expected, if the web tool did manage this it would be like
`return getScriptStorage()._cuf_gm.indirectCall({{call =" createSupplyDrop" , "energy" {call = "irandom", min = 0, max = 500}},"homing" = {call = "irandom", min = 0, max = 5}},"nuke" = {call = "irandom", min = 0, max = 5}},"mine" = {call = "irandom", min = 0, max = 5}},"emp" = {call = "irandom", min = 0, max = 5}},"hvli" = {call = "irandom", min = 0, max = 5}},"repairCrew" = {call = "irandom", min = 0, max = 1}},"coolant" = {call = "irandom", min = 0, max = 2}},"probes" = {call = "irandom", min = 0, max = 5}},"armour" = {call = "irandom", min = 0, max = 30}}})`

without any of onGMClick, editing updates, subspace_rift working in the sandbox (all are being done in the www tool) I cant find a real world example to show the chaining of functions and not why I wrap functions, 
the best example is the sat_tmp code which would generate
`return getScriptStorage()._cuf_gm.indirectCall({onclick = {start = {x = -0,y = 0},speed = 4000,endCallback = {max_time = 5,max_radius = 500,on_end = {max_time = 60,max_range = 5000,onEndCallback = {call = "null_function"},call = "jammer_pulse"},call = "subspace_rift"},call = "sat_tmp"},call = "gm_click_wrapper"})`
(for context these are the function signatures)
`function sat_tmp(start,dest,speed,endCallback)`
`function subspace_rift(max_time,location,max_radius,on_end)`
`function jammer_pulse(max_time,max_range,location,onEndCallback)`
the thing to note is that sat_tmp is able to call subspace_rift despite it only sending location (max_time, on_end and max_radius all are constants due to the wrapping) - the wrapping generates a function like
```
function subspace_rift_wrap(location)
  subspace_rift(60,5000,location,{call = "null_function"})
end
```
I dont know of a great name for this - the naming becomes very messy around there, currying comes to mind, but I think is the wrong term
I think this is very useful for the web tool (as everything can be set on the web tool), and requires minimal changes to the sandbox
caller_provides is used to signal what will be passed in from the caller (so in the above location) everything else is pulled from the original tables
_caller_provides_rename is very hard to show a use case for in the current state of the sandbox and web tool, it is to deal with the issue of names not matching between caller and callee (so the wrapper for ongmclick being location and subspace_rift being location), it should only be managed by the web tool, but presently the web tool cant use it

it would be nice if the web tool supported functions being called with arguments in order, but is doesnt buy much (I think), and was a source of a lot of bugs when I started, as such its for later

the web tool github has been updated to something that locally works with the current here, the UI for it is still very pre alpha like (there are some buttons you dont press as it will cause script errors etc), but may help for context

I'm torn as to if I should wait til more of these todo's can be fixed, but I'm pretty sure the this chunk of code wont need heavy changes as such I feel the time to merge is now, if you disagree I can just resubmit when there is a larger amount completed

If you need more details ask, but If im not careful I will spend all my time writing this rather than getting the web tool working and able to show you directly