### PR TITLE
Sandbox error handling p2

### DIFF
--- a/sandbox/errorHandling.lua
+++ b/sandbox/errorHandling.lua
@@ -17,11 +17,6 @@ errorHandling = {}
 --ScanProbe:onDestruction
 --ShipTemplateBasedObject:onTakingDamage
 --ShipTemplateBasedObject:onDestruction
---PlayerSpaceship:addCustomButton
---PlayerSpaceship:addCustomMessageWithCallback
---PlayerSpaceship:onProbeLaunch
---PlayerSpaceship:onProbeLink
---PlayerSpaceship:onProbeUnlink
 -- TODO - mirror the class hierachy (needed for the SpaceObject callbacks)
 --SpaceObject
 --    Artifact
@@ -116,6 +111,19 @@ function errorHandling:_SupplyDrop()
 	end
 end
 
+function errorHandling:_PlayerSpaceship()
+	local create = PlayerSpaceship
+	return function()
+		local ship = create()
+			ship.addCustomButton = self:_autoWrapArgX(ship.addCustomButton,5)
+			ship.addCustomMessageWithCallback = self:_autoWrapArgX(ship.addCustomMessageWithCallback,5)
+			ship.onProbeLaunch = self:_autoWrapArgX(ship.onProbeLaunch,2)
+			ship.onProbeLink = self:_autoWrapArgX(ship.onProbeLink,2)
+			ship.onProbeUnlink = self:_autoWrapArgX(ship.onProbeUnlink,2)
+		return ship
+	end
+end
+
 -- the main function here - it wraps all functions with error handling code
 function errorHandling:_wrapAllFunctions()
 	addGMFunction = self:_autoWrapArgX(addGMFunction,2)
@@ -130,6 +138,7 @@ function errorHandling:_wrapAllFunctions()
 	WormHole = self:WormHole()
 	WarpJammer = self:_WarpJammer()
 	SupplyDrop = self:_SupplyDrop()
+	PlayerSpaceship = self:_PlayerSpaceship()
 end
 
 -- this is a wrapper to allow us to catch errors in the error handling code

--- a/sandbox/errorHandling.lua
+++ b/sandbox/errorHandling.lua
@@ -97,7 +97,7 @@ function errorHandling:WormHole()
 	end
 end
 
-function errorHandling:WarpJammer()
+function errorHandling:_WarpJammer()
 	local create = WarpJammer
 	return function()
 		local jammer = create()
@@ -107,7 +107,7 @@ function errorHandling:WarpJammer()
 	end
 end
 
-function errorHandling:SupplyDrop()
+function errorHandling:_SupplyDrop()
 	local create = SupplyDrop
 	return function()
 		local drop = create()
@@ -128,8 +128,8 @@ function errorHandling:_wrapAllFunctions()
 	init = self:wrapWithErrorHandling(init)
 
 	WormHole = self:WormHole()
-	WarpJammer = self:WarpJammer()
-	SupplyDrop = self:SupplyDrop()
+	WarpJammer = self:_WarpJammer()
+	SupplyDrop = self:_SupplyDrop()
 end
 
 -- this is a wrapper to allow us to catch errors in the error handling code

--- a/sandbox/errorHandling.lua
+++ b/sandbox/errorHandling.lua
@@ -22,6 +22,33 @@ errorHandling = {}
 --PlayerSpaceship:onProbeLaunch
 --PlayerSpaceship:onProbeLink
 --PlayerSpaceship:onProbeUnlink
+-- TODO - mirror the class hierachy (needed for the SpaceObject callbacks)
+--SpaceObject
+--    Artifact
+--    Asteroid
+--    BeamEffect
+--    BlackHole
+--    ElectricExplosionEffect
+--    ExplosionEffect
+--    Mine
+--    MissileWeapon
+--        EMPMissile
+--        HVLI
+--        HomingMissile
+--        Nuke
+--    Nebula
+--    Planet
+--    ScanProbe
+--    ShipTemplateBasedObject
+--        SpaceShip
+--            CpuShip
+--            PlayerSpaceship
+--        SpaceStation
+--    SupplyDrop
+--    VisualAsteroid
+--    WarpJammer
+--    WormHole
+--    Zone
 -- note - its worth checking the gm create menu (or other ways) uses these functions rather than the C++ version
 -- player ship is perticullary important
 -- it might be good to make some of these optional

--- a/sandbox/library.lua
+++ b/sandbox/library.lua
@@ -2,6 +2,7 @@
 -- it is intended to be able to be included in an empty script and function correctly
 -- this is probably not yet the case especially with the update system 
 
+-- todo fix webcall
 ----------------------
 -- debug assistance --
 ----------------------

--- a/sandbox/main.lua
+++ b/sandbox/main.lua
@@ -25845,9 +25845,7 @@ function playerPower()
 	return playerShipScore
 end
 function wrapAddCustomButtons(p)
-	p.wrappedAddCustomButton = function(player,position,name,caption,callback) -- missing index for next EE version
-		customElements:addCustomButton(player,position,name,caption,errorHandling:wrapWithErrorHandling(callback))
-	end
+	p.wrappedAddCustomButton = function(...) customElements:addCustomButton(...) end
 	p.wrappedAddCustomInfo = function(...) customElements:addCustomInfo(...) end
 	p.wrappedAddCustomMessageWithCallback = function(...) customElements:addCustomMessageWithCallback(...) end
 	p.wrappedAddCustomMessage = function(...) customElements:addCustomMessage(...) end


### PR DESCRIPTION
includes playership callbacks (which IMO are some of the most important)
as mentioned in one of the comments the ShipTemplateBasedObject dont seem to be firing all the time
I think this is an issue with stock EE & I want to investigate it, I'm fairly sure its not made worse via this pull request, but it is hard to be 100% certain