### PR TITLE
Automatically create a zip file of just the sandbox

### DIFF
--- a/.github/workflows/package-sandbox.yaml
+++ b/.github/workflows/package-sandbox.yaml
@@ -1,0 +1,12 @@
+name: package-sandbox
+on: [push]
+jobs:
+  package-sandbox:
+    runs-on: ubuntu-latest
+    steps:
+      - run: zip -r Sandbox.zip scenario_09_sandbox.lua sandbox
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Sandbox Download
+          path: Sandbox.zip
+          overwrite: true

--- a/.github/workflows/package-sandbox.yaml
+++ b/.github/workflows/package-sandbox.yaml
@@ -4,6 +4,7 @@ jobs:
   package-sandbox:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - run: zip -r Sandbox.zip scenario_09_sandbox.lua sandbox
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package-sandbox.yaml
+++ b/.github/workflows/package-sandbox.yaml
@@ -8,6 +8,6 @@ jobs:
       - run: zip -r Sandbox.zip scenario_09_sandbox.lua sandbox
       - uses: actions/upload-artifact@v4
         with:
-          name: Sandbox Download
+          name: Sandbox
           path: Sandbox.zip
           overwrite: true


### PR DESCRIPTION
You can then e.g. use a link like this:

https://nightly.link/jstsmthrgk/EEScenarios/workflows/package-sandbox.yaml/master/Sandbox.zip

to download the automatically created zip file.

(This is using https://nightly.link , because unlike GitLab, GitHub doesn't expose the functionality to get the latest build artifacts directly itself)
